### PR TITLE
update chrome linux certificate installation instructions

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -189,7 +189,7 @@
       </span>
       <span class="instructions-chrome-linux">
         Save the *.p12 file, then import it at Settings → Privacy &amp; Security
-        → Security → Manage certificates → Your Certificates → Import.
+        → Security → Manage device certificates → Your Certificates → Import.
       </span>
       <span class="instructions-firefox-windows">
         Save the *.p12 file, then import it at Options → Privacy &amp; Security


### PR DESCRIPTION
Thanks for the great tool! I just used it with Chrome on Linux and there was a small difference in the browser instructions. This PR changes "Manage certificates" -> "Manage device certificates" which is what appears in Chrome (for me anyway).

![image](https://github.com/sipb/certassist/assets/33505528/d251b817-7c82-4803-9cf1-6190ce5ec4fa)
